### PR TITLE
Erlang 24.1 Compatibility

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,121 @@
+name: Test
+on:
+  push:
+jobs:
+  test:
+    container:
+      image: debian:buster
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.3.4
+        with:
+          path: package-sources
+      - name: Checkout otp
+        uses: actions/checkout@v2.3.4
+        with:
+          repository: erlang/otp
+          ref: maint-24
+          path: erlang-sources
+      - name: Build package
+        run: |
+          set -x
+
+          ls
+
+          if test -f /etc/debian_version; then
+            dist_version=debian-$(cat /etc/debian_version)
+          fi
+
+          export DEBIAN_FRONTEND=noninteractive
+
+          apt-get update
+          apt-get install -y tzdata
+
+          echo "Europe/London" > /etc/timezone
+          dpkg-reconfigure -f noninteractive tzdata
+
+          apt-get install -y --no-install-recommends \
+            build-essential \
+            ca-certificates \
+            devscripts \
+            equivs \
+            git \
+            gnupg \
+            rsync
+
+          apt-get install -y --no-install-recommends git-buildpackage
+
+          cd erlang-sources
+
+          cp -a ../package-sources/debian .
+
+          branch=erlang-debian-package-by-rabbitmq
+          version=$(git describe --tags --abbrev=10)
+          case "$version" in
+            OTP-*)
+              version=$(echo "$version" | \
+                sed -E \
+                -e 's/^OTP-//' \
+                -e 's/-/~/' \
+                -e 's/-/./')
+              ;;
+            OTP_*)
+              version=$(echo "$version" | \
+                sed -E \
+                -e 's/OTP_R([1-9]+)B0*([1-9]+)($|-([0-9]+))/\1.b.\2\3/' \
+                -e 's/-/./')
+              ;;
+            *)
+              exit 1
+              ;;
+          esac
+
+          if test "$(git rev-parse HEAD)" = "$(git rev-parse master)"; then
+            # If we are on the `master` branch of Erlang, the last tag doesn't
+            # match the future version of Erlang. Let's construct the version from
+            # the `OTP_VERSION` file.
+            future_version=$(cat OTP_VERSION)
+            future_version=${future_version%-*}
+            version=$(echo "$version" | sed -E 's/([^~]+)/'"$future_version"'/')
+          fi
+
+          tag=upstream-tag-for-debian-package
+
+          git rev-parse "$tag" -- >/dev/null 2>&1 || git tag "$tag"
+          git checkout -b "$branch"
+
+          # Remove non-free documentation.
+          for fn in $(find lib/*/doc -name standard -or -name archive); do
+            rm -rf "$fn"
+          done
+
+          # --------------------------------------------------------------------
+          # Configure git-buildpackage.
+          # --------------------------------------------------------------------
+
+          cat > ~/.gbp.conf <<EOF
+          [DEFAULT]
+          upstream-tag = $tag
+          EOF
+
+          # --------------------------------------------------------------------
+          # Build package.
+          # --------------------------------------------------------------------
+
+          mk-build-deps -i \
+            -t 'apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y'
+          rm -f erlang-build-deps*
+
+          gbp buildpackage \
+            --git-ignore-new \
+            --git-debian-branch="$branch"
+
+          # --------------------------------------------------------------------
+          # Move final package.
+          # --------------------------------------------------------------------
+
+          cd ..
+
+          mv *.dsc *.changes *.deb PACKAGES
+

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,12 +16,11 @@ jobs:
         with:
           repository: erlang/otp
           ref: maint-24
+          fetch-depth: 0
           path: erlang-sources
       - name: Build package
         run: |
           set -x
-
-          ls
 
           if test -f /etc/debian_version; then
             dist_version=debian-$(cat /etc/debian_version)

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,6 +7,12 @@ jobs:
       image: debian:buster
     runs-on: ubuntu-latest
     steps:
+      - name: Install Git
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            ca-certificates \
+            git
       - name: Checkout
         uses: actions/checkout@v2.3.4
         with:
@@ -28,7 +34,6 @@ jobs:
 
           export DEBIAN_FRONTEND=noninteractive
 
-          apt-get update
           apt-get install -y tzdata
 
           echo "Europe/London" > /etc/timezone
@@ -36,10 +41,8 @@ jobs:
 
           apt-get install -y --no-install-recommends \
             build-essential \
-            ca-certificates \
             devscripts \
             equivs \
-            git \
             gnupg \
             rsync
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -111,13 +111,5 @@ jobs:
 
           gbp buildpackage \
             --git-ignore-new \
-            --git-debian-branch="$branch"
-
-          # --------------------------------------------------------------------
-          # Move final package.
-          # --------------------------------------------------------------------
-
-          cd ..
-
-          mv *.dsc *.changes *.deb PACKAGES
-
+            --git-debian-branch="$branch" \
+            --no-sign

--- a/debian/README.Debian
+++ b/debian/README.Debian
@@ -27,8 +27,8 @@ GDK_BACKEND=x11 wings3d
 
 ----------------
 
-Starting from version 1:21.2.2+dfsg-1 the erlang-base and erlang-base-hipe
-packages provide systemd socket and unit files for the epmd daemon, which
+Starting from version 1:21.2.2+dfsg-1 the erlang-base
+package provides systemd socket and unit files for the epmd daemon, which
 are enabled by default. This causes the executed epmd to be owned by a separate
 user which is more secure in multi-user environment. (By default, the first
 distributed Erlang application starts the epmd daemon, and then it can kill
@@ -56,7 +56,20 @@ systemctl daemon-reload
 
 and start epmd.socket. After that epmd will listen on loopback only.
 
-Alternatively, you could use a firewall to block unwanted connections to epmd.
+Alternatively, you could add the following directives to the epmd.socket:
+
+systemctl edit epmd.socket
+
+And then add:
+
+[Socket]
+IPAddressDeny=any
+IPAddressAllow=localhost
+
+(An option takes a list of networks for its value.
+See systemd.resource-control(5) for details.)
+
+And of course, you could use a firewall to block unwanted connections to epmd.
 
 If you never plan to use distributed Erlang, you can disable or even mask the
 epmd units, e.g.

--- a/debian/TODO.Debian
+++ b/debian/TODO.Debian
@@ -1,8 +1,0 @@
-Things we hope in the next versions of this package:
-
-* Build and package erl_jinterface. JInterface is not built
-in the main package since it doesn't not depend on Java.
-
-* Add kernel-poll support and HiPE to kfreebsd-i386 and kfreebsd-amd64
-architecture (It seems to be possible).
-

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Uploaders: Sergei Golovan <sgolovan@debian.org>
 Section: interpreters
 Priority: optional
 Standards-Version: 4.5.1
-Build-Depends: debhelper (>= 10.0.0), autoconf (>= 2.50), openssl, libssl-dev, m4,
+Build-Depends: debhelper (>= 10.0.0), autoconf (>= 2.71), openssl, libssl-dev, m4,
  libncurses5-dev, unixodbc-dev, bison, flex, ed, zlib1g-dev,
  libwxgtk3.0-gtk3-dev, libwxgtk-webview3.0-gtk3-dev, libx11-dev, dctrl-tools, xsltproc,
  libgl1-mesa-dev | libgl-dev, libglu1-mesa-dev | libglu-dev,

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Uploaders: Sergei Golovan <sgolovan@debian.org>
 Section: interpreters
 Priority: optional
 Standards-Version: 4.5.1
-Build-Depends: debhelper (>= 10.0.0), autoconf (>= 2.71), openssl, libssl-dev, m4,
+Build-Depends: debhelper (>= 10.0.0), autoconf (>= 2.69), openssl, libssl-dev, m4,
  libncurses5-dev, unixodbc-dev, bison, flex, ed, zlib1g-dev,
  libwxgtk3.0-gtk3-dev, libwxgtk-webview3.0-gtk3-dev, libx11-dev, dctrl-tools, xsltproc,
  libgl1-mesa-dev | libgl-dev, libglu1-mesa-dev | libglu-dev,

--- a/debian/control.in
+++ b/debian/control.in
@@ -4,7 +4,7 @@ Uploaders: Sergei Golovan <sgolovan@debian.org>
 Section: interpreters
 Priority: optional
 Standards-Version: 4.5.1
-Build-Depends: debhelper (>= 10.0.0), autoconf (>= 2.50), openssl, libssl-dev, m4,
+Build-Depends: debhelper (>= 10.0.0), autoconf (>= 2.71), openssl, libssl-dev, m4,
  libncurses5-dev, unixodbc-dev, bison, flex, ed, zlib1g-dev,
  libwxgtk3.0-gtk3-dev, libwxgtk-webview3.0-gtk3-dev, libx11-dev, dctrl-tools, xsltproc,
  libgl1-mesa-dev | libgl-dev, libglu1-mesa-dev | libglu-dev,
@@ -18,7 +18,7 @@ Vcs-Git: https://salsa.debian.org/erlang-team/packages/erlang.git
 Package: erlang-base
 Architecture: any
 Multi-Arch: allowed
-Depends: procps, adduser, ${misc:Depends}
+Depends: procps, adduser, ${shlibs:Depends}, ${misc:Depends}
 Recommends: ${libsctp:Version}, erlang-crypto (= ${binary:Version}), erlang-syntax-tools (= ${binary:Version})
 Suggests: erlang-tools (= ${binary:Version}),  erlang, erlang-manpages, erlang-doc
 Conflicts: erlang (<< ${source:Version}), erlang-base-hipe, erlang-doc (<< ${source:Upstream-Version}), erlang-doc (>> ${source:Upstream-Version}-999), erlang-manpages (<= 1:11.b.1-2), erlang-doc-html (<< 1:13.b.4)
@@ -39,7 +39,7 @@ Description: Erlang/OTP virtual machine and base applications
 Package: erlang-asn1
 Architecture: any
 Multi-Arch: allowed
-Depends: ${erlang-base}, ${misc:Depends}
+Depends: ${erlang-base}, ${shlibs:Depends}, ${misc:Depends}
 Suggests: erlang, erlang-manpages, erlang-doc
 Replaces: erlang (<< ${source:Version}), erlang-base (<< ${binary:Version}), erlang-base-hipe, erlang-nox (<< ${source:Version}), erlang-x11 (<< ${binary:Version}), erlang-src (<< ${source:Version}), erlang-dev (<< ${binary:Version}), erlang-examples (<< ${source:Version}), erlang-mode (<< 1:12.b.1-dfsg-2), erlang-doc (<< ${source:Upstream-Version}), erlang-doc (>> ${source:Upstream-Version}-999), erlang-manpages (<= 1:11.b.1-2)
 Description: Erlang/OTP modules for ASN.1 support
@@ -50,7 +50,7 @@ Description: Erlang/OTP modules for ASN.1 support
 Package: erlang-common-test
 Architecture: any
 Multi-Arch: allowed
-Depends: ${erlang-base}, erlang-crypto (= ${binary:Version}), erlang-debugger (= ${binary:Version}), erlang-ftp (= ${binary:Version}), erlang-inets (= ${binary:Version}), erlang-observer (= ${binary:Version}), erlang-runtime-tools (= ${binary:Version}), erlang-snmp (= ${binary:Version}), erlang-ssh (= ${binary:Version}), erlang-syntax-tools (= ${binary:Version}), erlang-tools (= ${binary:Version}), erlang-xmerl (= ${binary:Version}), libjs-jquery, libjs-jquery-tablesorter, ${misc:Depends}
+Depends: ${erlang-base}, erlang-crypto (= ${binary:Version}), erlang-debugger (= ${binary:Version}), erlang-ftp (= ${binary:Version}), erlang-inets (= ${binary:Version}), erlang-observer (= ${binary:Version}), erlang-runtime-tools (= ${binary:Version}), erlang-snmp (= ${binary:Version}), erlang-ssh (= ${binary:Version}), erlang-syntax-tools (= ${binary:Version}), erlang-tools (= ${binary:Version}), erlang-xmerl (= ${binary:Version}), libjs-jquery, libjs-jquery-tablesorter, ${shlibs:Depends}, ${misc:Depends}
 Suggests: erlang, erlang-manpages, erlang-doc
 Replaces: erlang (<< ${source:Version}), erlang-base (<< ${binary:Version}), erlang-base-hipe, erlang-nox (<< ${source:Version}), erlang-x11 (<< ${binary:Version}), erlang-src (<< ${source:Version}), erlang-dev (<< ${binary:Version}), erlang-examples (<< ${source:Version}), erlang-mode (<< 1:12.b.1-dfsg-2), erlang-doc (<< ${source:Upstream-Version}), erlang-doc (>> ${source:Upstream-Version}-999), erlang-manpages (<= 1:11.b.1-2)
 Description: Erlang/OTP application for automated testing
@@ -69,7 +69,7 @@ Description: Erlang/OTP application for automated testing
 Package: erlang-crypto
 Architecture: any
 Multi-Arch: allowed
-Depends: ${erlang-base}, ${misc:Depends}
+Depends: ${erlang-base}, ${shlibs:Depends}, ${misc:Depends}
 Suggests: erlang, erlang-manpages, erlang-doc
 Replaces: erlang (<< ${source:Version}), erlang-base (<< ${binary:Version}), erlang-base-hipe, erlang-nox (<< ${source:Version}), erlang-x11 (<< ${binary:Version}), erlang-src (<< ${source:Version}), erlang-dev (<< ${binary:Version}), erlang-examples (<< ${source:Version}), erlang-mode (<< 1:12.b.1-dfsg-2), erlang-doc (<< ${source:Upstream-Version}), erlang-doc (>> ${source:Upstream-Version}-999), erlang-manpages (<= 1:11.b.1-2)
 Description: Erlang/OTP cryptographic modules
@@ -94,7 +94,7 @@ Description: Erlang/OTP application for debugging and testing
 Package: erlang-dialyzer
 Architecture: any
 Multi-Arch: allowed
-Depends: ${erlang-base}, erlang-syntax-tools (=${binary:Version}), ${misc:Depends}
+Depends: ${erlang-base}, erlang-syntax-tools (=${binary:Version}), ${shlibs:Depends}, ${misc:Depends}
 Suggests: erlang-wx (= ${binary:Version}), erlang, erlang-manpages, erlang-doc
 Replaces: erlang (<< ${source:Version}), erlang-base (<< ${binary:Version}), erlang-base-hipe, erlang-nox (<< ${source:Version}), erlang-x11 (<< ${binary:Version}), erlang-src (<< ${source:Version}), erlang-dev (<< ${binary:Version}), erlang-examples (<< ${source:Version}), erlang-mode (<< 1:12.b.1-dfsg-2), erlang-doc (<< ${source:Upstream-Version}), erlang-doc (>> ${source:Upstream-Version}-999), erlang-manpages (<= 1:11.b.1-2)
 Description: Erlang/OTP discrepancy analyzer application
@@ -221,7 +221,7 @@ Description: Erlang/OTP manual pages
 Package: erlang-megaco
 Architecture: any
 Multi-Arch: allowed
-Depends: ${erlang-base}, erlang-asn1 (= ${binary:Version}), erlang-runtime-tools (= ${binary:Version}), ${misc:Depends}
+Depends: ${erlang-base}, erlang-asn1 (= ${binary:Version}), erlang-runtime-tools (= ${binary:Version}), ${shlibs:Depends}, ${misc:Depends}
 Suggests: erlang-debugger (= ${binary:Version}), erlang-et (= ${binary:Version}), erlang, erlang-manpages, erlang-doc
 Replaces: erlang (<< ${source:Version}), erlang-base (<< ${binary:Version}), erlang-base-hipe, erlang-nox (<< ${source:Version}), erlang-x11 (<< ${binary:Version}), erlang-src (<< ${source:Version}), erlang-dev (<< ${binary:Version}), erlang-examples (<< ${source:Version}), erlang-mode (<< 1:12.b.1-dfsg-2), erlang-doc (<< ${source:Upstream-Version}), erlang-doc (>> ${source:Upstream-Version}-999), erlang-manpages (<= 1:11.b.1-2)
 Description: Erlang/OTP implementation of Megaco/H.248 protocol
@@ -257,7 +257,7 @@ Description: Erlang/OTP application for investigating distributed systems
 Package: erlang-odbc
 Architecture: any
 Multi-Arch: allowed
-Depends: ${erlang-base}, ${misc:Depends}
+Depends: ${erlang-base}, ${shlibs:Depends}, ${misc:Depends}
 Suggests: erlang, erlang-manpages, erlang-doc
 Replaces: erlang (<< ${source:Version}), erlang-base (<< ${binary:Version}), erlang-base-hipe, erlang-nox (<< ${source:Version}), erlang-x11 (<< ${binary:Version}), erlang-src (<< ${source:Version}), erlang-dev (<< ${binary:Version}), erlang-examples (<< ${source:Version}), erlang-mode (<< 1:12.b.1-dfsg-2), erlang-doc (<< ${source:Upstream-Version}), erlang-doc (>> ${source:Upstream-Version}-999), erlang-manpages (<= 1:11.b.1-2)
 Description: Erlang/OTP interface to SQL databases
@@ -268,7 +268,7 @@ Description: Erlang/OTP interface to SQL databases
 Package: erlang-os-mon
 Architecture: any
 Multi-Arch: allowed
-Depends: ${erlang-base}, erlang-mnesia (= ${binary:Version}), erlang-snmp (= ${binary:Version}), ${misc:Depends}
+Depends: ${erlang-base}, erlang-mnesia (= ${binary:Version}), erlang-snmp (= ${binary:Version}), ${shlibs:Depends}, ${misc:Depends}
 Suggests: erlang, erlang-manpages, erlang-doc
 Replaces: erlang (<< ${source:Version}), erlang-base (<< ${binary:Version}), erlang-base-hipe, erlang-nox (<< ${source:Version}), erlang-x11 (<< ${binary:Version}), erlang-src (<< ${source:Version}), erlang-dev (<< ${binary:Version}), erlang-examples (<< ${source:Version}), erlang-mode (<< 1:12.b.1-dfsg-2), erlang-doc (<< ${source:Upstream-Version}), erlang-doc (>> ${source:Upstream-Version}-999), erlang-manpages (<= 1:11.b.1-2)
 Description: Erlang/OTP operating system monitor
@@ -317,7 +317,7 @@ Description: Erlang/OTP release management tool
 Package: erlang-runtime-tools
 Architecture: any
 Multi-Arch: allowed
-Depends: ${erlang-base}, erlang-mnesia (= ${binary:Version}), ${misc:Depends}
+Depends: ${erlang-base}, erlang-mnesia (= ${binary:Version}), ${shlibs:Depends}, ${misc:Depends}
 Suggests: erlang, erlang-manpages, erlang-doc
 Replaces: erlang (<< ${source:Version}), erlang-base (<< ${binary:Version}), erlang-base-hipe, erlang-nox (<< ${source:Version}), erlang-x11 (<< ${binary:Version}), erlang-src (<< ${source:Version}), erlang-dev (<< ${binary:Version}), erlang-examples (<< ${source:Version}), erlang-mode (<< 1:12.b.1-dfsg-2), erlang-doc (<< ${source:Upstream-Version}), erlang-doc (>> ${source:Upstream-Version}-999), erlang-manpages (<= 1:11.b.1-2)
 Description: Erlang/OTP runtime tracing/debugging tools
@@ -390,7 +390,7 @@ Description: Erlang/OTP TFTP client and server
 Package: erlang-tools
 Architecture: any
 Multi-Arch: allowed
-Depends: ${erlang-base}, erlang-runtime-tools (= ${binary:Version}), ${misc:Depends}
+Depends: ${erlang-base}, erlang-runtime-tools (= ${binary:Version}), ${shlibs:Depends}, ${misc:Depends}
 Suggests: erlang, erlang-manpages, erlang-doc
 Replaces: erlang (<< ${source:Version}), erlang-base (<< ${binary:Version}), erlang-base-hipe, erlang-nox (<< ${source:Version}), erlang-x11 (<< ${binary:Version}), erlang-src (<< ${source:Version}), erlang-dev (<< ${binary:Version}), erlang-examples (<< ${source:Version}), erlang-mode (<< 1:12.b.1-dfsg-2), erlang-doc (<< ${source:Upstream-Version}), erlang-doc (>> ${source:Upstream-Version}-999), erlang-manpages (<= 1:11.b.1-2)
 Description: Erlang/OTP various tools
@@ -418,7 +418,7 @@ Description: Erlang/OTP various tools
 Package: erlang-wx
 Architecture: any
 Multi-Arch: allowed
-Depends: ${erlang-base}, ${misc:Depends}
+Depends: ${erlang-base}, ${shlibs:Depends}, ${misc:Depends}
 Suggests: erlang, erlang-manpages, erlang-doc
 Replaces: erlang (<< ${source:Version}), erlang-base (<< ${binary:Version}), erlang-base-hipe, erlang-nox (<< ${source:Version}), erlang-x11 (<< ${binary:Version}), erlang-src (<< ${source:Version}), erlang-dev (<< ${binary:Version}), erlang-examples (<< ${source:Version}), erlang-mode (<< 1:12.b.1-dfsg-2), erlang-doc (<< ${source:Upstream-Version}), erlang-doc (>> ${source:Upstream-Version}-999), erlang-manpages (<= 1:11.b.1-2)
 Description: Erlang/OTP bindings to wxWidgets

--- a/debian/control.in
+++ b/debian/control.in
@@ -4,7 +4,7 @@ Uploaders: Sergei Golovan <sgolovan@debian.org>
 Section: interpreters
 Priority: optional
 Standards-Version: 4.5.1
-Build-Depends: debhelper (>= 10.0.0), autoconf (>= 2.71), openssl, libssl-dev, m4,
+Build-Depends: debhelper (>= 10.0.0), autoconf (>= 2.69), openssl, libssl-dev, m4,
  libncurses5-dev, unixodbc-dev, bison, flex, ed, zlib1g-dev,
  libwxgtk3.0-gtk3-dev, libwxgtk-webview3.0-gtk3-dev, libx11-dev, dctrl-tools, xsltproc,
  libgl1-mesa-dev | libgl-dev, libglu1-mesa-dev | libglu-dev,

--- a/debian/patches/autoconfversion.patch
+++ b/debian/patches/autoconfversion.patch
@@ -1,0 +1,11 @@
+--- a/otp_build
++++ b/otp_build
+@@ -19,7 +19,7 @@
+ # %CopyrightEnd%
+ #
+ 
+-USE_AUTOCONF_VERSION=2.69
++USE_AUTOCONF_VERSION=2.71
+ 
+ aclocal_dirs="make ./lib/crypto ./lib/erl_interface ./lib/odbc ./lib/wx ./lib/megaco"
+ autoconf_aux_dirs="./lib/common_test/priv/auxdir ./lib/erl_interface/src/auxdir ./lib/common_test/test_server ./lib/wx/autoconf"

--- a/debian/patches/clean.patch
+++ b/debian/patches/clean.patch
@@ -5,7 +5,7 @@ a hack to remove them.
 
 --- a/Makefile.in
 +++ b/Makefile.in
-@@ -1169,6 +1169,7 @@
+@@ -1184,6 +1184,7 @@
  	rm -f *~ *.bak config.log config.status prebuilt.files ibin/*
  	cd erts && ERL_TOP=$(ERL_TOP) $(MAKE) clean
  	cd lib  && ERL_TOP=$(ERL_TOP) $(MAKE) clean BUILD_ALL=true
@@ -13,7 +13,7 @@ a hack to remove them.
  
  distclean: clean
  	find . -type f -name SKIP              -print | xargs $(RM)
-@@ -1218,3 +1219,204 @@
+@@ -1233,3 +1234,204 @@
  
  dialyzer: all
  	$(ERL_TOP)/scripts/run-dialyzer

--- a/debian/patches/java.patch
+++ b/debian/patches/java.patch
@@ -8,7 +8,7 @@ Last-updated: Sat, 13 Feb 2010 10:08:42 +0300
 
 --- a/erts/configure.in
 +++ b/erts/configure.in
-@@ -3402,7 +3402,8 @@
+@@ -3411,7 +3411,8 @@
    dnl Make sure it's at least JDK 1.6
    AC_CACHE_CHECK(for JDK version 1.6, 
       ac_cv_prog_javac_ver_1_6,

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,6 +1,4 @@
-autoconfversion.patch
 clean.patch
-gnu.patch
 man.patch
 emacs.patch
 docs.patch

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,3 +1,4 @@
+autoconfversion.patch
 clean.patch
 gnu.patch
 man.patch

--- a/debian/rules
+++ b/debian/rules
@@ -63,6 +63,13 @@ endif
 LIBSCTP=$(shell grep-status -s Depends -PX libsctp-dev |sed -e 's!.*\(libsctp[0-9]*\).*!\1!')
 LIBSCTPDEP=$(shell grep-status -s Version -PX $(LIBSCTP) | sed -e's!^Version: \(.*\)-[^-]*!$(LIBSCTP) (>= \1)!')
 
+USE_SCTP := $(shell echo ${DEB_HOST_ARCH} | egrep -c "bsd|hurd" | sed -es/1/no/ -es/0/yes/)
+ifeq ($(USE_SCTP), no)
+SCTP_OPT=--disable-sctp
+else
+SCTP_OPT=--enable-sctp
+endif
+
 ifeq ($(findstring debug,$(DEB_BUILD_OPTIONS)),debug)
 CFLAGS=-g -O2 -fno-strict-aliasing
 GEN_OPT_FLGS=-O2 -fno-strict-aliasing
@@ -165,7 +172,7 @@ automake-stamp: debian/control
 	done
 	#
 	# Regenerate configure scripts using autoconf
-	./otp_build autoconf
+	./otp_build update_configure --no-commit
 	#
 	touch automake-stamp
 
@@ -190,7 +197,7 @@ configure-stnd-stamp: automake-stamp
 		    $(KERNEL_POLL_OPT) \
 		    $(ESOCKET_OPT) \
 		    $(SYSTEMD_OPT) \
-		    --enable-sctp \
+		    $(SCTP_OPT) \
 		    $(CLOCK_GETTIME_OPT) \
 		    --enable-dynamic-ssl-lib \
 		    --with-ssl-rpath=no \


### PR DESCRIPTION
Allow building of erlang/otp 24.1

Also adds a GitHub Actions workflow to test the package build (however the true build/publish is still left up to Concourse)